### PR TITLE
Fix iterator example usage to not crash

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -34,9 +34,7 @@ func (e IteratorError) Error() string {
 //
 // 	it := db.NewIterator(readOpts)
 // 	defer it.Close()
-// 	it.Seek(mykey)
-// 	for it.Valid() {
-// 		it.Next()
+// 	for it.Seek(mykey); it.Valid(); it.Next() {
 // 		useKeyAndValue(it.Key(), it.Value())
 // 	}
 // 	if err := it.GetError() {


### PR DESCRIPTION
The example used an "off by one" looping error. The iterator points to the first value after the seek, but the body called `Next()` before that first value was used. Also, because it's one too far forward, it would `Next()` past the last entry and calling `Value()` caused a panic.
