### PR TITLE
Initial Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+  - 1.1
+  - 1.2
+  - 1.3
+  - tip
+
+install: true
+
+script: cd .travis && make
+

--- a/.travis/.gitignore
+++ b/.travis/.gitignore
@@ -1,0 +1,3 @@
+archives
+root
+

--- a/.travis/Makefile
+++ b/.travis/Makefile
@@ -1,0 +1,50 @@
+all: test
+
+LEVELDB_VERSION ?= v1.18
+SNAPPY_VERSION ?= 1.1.1
+
+export CFLAGS ?= -I$(PWD)/root/snappy-$(SNAPPY_VERSION)/include
+export CXXFLAGS ?= -I$(PWD)/root/snappy-$(SNAPPY_VERSION)/include
+export LDFLAGS ?= -L$(PWD)/root/snappy-$(SNAPPY_VERSION)/lib
+export CGO_CFLAGS ?= -I$(PWD)/root/snappy-$(SNAPPY_VERSION)/include -I$(PWD)/root/leveldb/include
+export CGO_LDFLAGS ?= -L$(PWD)/root/snappy-$(SNAPPY_VERSION)/lib -L$(PWD)/root/leveldb -lsnappy
+export GOPATH ?= $(PWD)/root/go
+export LD_LIBRARY_PATH := $(PWD)/root/snappy-$(SNAPPY_VERSION)/lib:$(PWD)/root/leveldb:$(LD_LIBRARY_PATH)
+
+archives/snappy-$(SNAPPY_VERSION).tar.gz: archives
+	curl https://snappy.googlecode.com/files/snappy-$(SNAPPY_VERSION).tar.gz > $@
+
+archives:
+	mkdir -v archives
+
+levigo: root/snappy-$(SNAPPY_VERSION)/STAMP root/leveldb/STAMP
+	cd ../ && go get -d .
+	cd ../ && go build .
+	cd ../ && go test -test.v=true .
+
+root:
+	mkdir -v root
+
+root/leveldb: root
+	cd root && git clone https://github.com/google/leveldb.git
+
+root/leveldb/STAMP: root/leveldb root/snappy-$(SNAPPY_VERSION)/STAMP
+	cd root/leveldb && git checkout $(LEVELDB_VERSION)
+	$(MAKE) -C root/leveldb
+	touch $@
+
+root/snappy-$(SNAPPY_VERSION): archives/snappy-$(SNAPPY_VERSION).tar.gz root
+	tar xzvf archives/snappy-$(SNAPPY_VERSION).tar.gz -C root
+
+root/snappy-$(SNAPPY_VERSION)/STAMP: root/snappy-$(SNAPPY_VERSION)
+	cd root/snappy-$(SNAPPY_VERSION) && ./configure --prefix=$$(pwd)
+	$(MAKE) -C root/snappy-$(SNAPPY_VERSION) install
+	touch $@
+
+test: levigo
+
+clean:
+	-rm -rf archives
+	-rm -rf root
+
+.PHONY: levigo test

--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ LevelDB C API available to your in your client package when you import levigo.
 
 An example of writing your own Comparator can be found in
 <https://github.com/jmhodges/levigo/blob/master/examples>.
+
+## Status
+
+Build: [![Build Status](https://travis-ci.org/jmhodges/levigo.svg)](https://travis-ci.org/jmhodges/levigo)
+
+Documentation: [![GoDoc](https://godoc.org/github.com/jmhodges/levigo?status.svg)](https://godoc.org/github.com/jmhodges/levigo)
+
+Lint: [Go Lint](http://go-lint.appspot.com/github.com/jmhodges/levigo)


### PR DESCRIPTION
This commit introduces a Travis CI configuration for Levigo, which
will setup a semi-deterministic test environment for Levigo itself,
including dependencies and does not rely upon brittle assumptions of
Travis outside of build essentials and curl.

It is a child of https://github.com/jmhodges/levigo/pull/28.
