### PR TITLE
Fix golint warnings where practical.

### DIFF
--- a/db.go
+++ b/db.go
@@ -28,10 +28,11 @@ import (
 	"unsafe"
 )
 
+// DatabaseError wraps general internal LevelDB errors for user consumption.
 type DatabaseError string
 
 func (e DatabaseError) Error() string {
-	return string(e)
+	return "levigo: " + string(e)
 }
 
 // DB is a reusable handle to a LevelDB database on disk, created by Open.

--- a/filterpolicy.go
+++ b/filterpolicy.go
@@ -27,6 +27,7 @@ func NewBloomFilter(bitsPerKey int) *FilterPolicy {
 	return &FilterPolicy{policy}
 }
 
+// Close reaps the resources associated with this FilterPolicy.
 func (fp *FilterPolicy) Close() {
 	C.leveldb_filterpolicy_destroy(fp.Policy)
 }

--- a/iterator.go
+++ b/iterator.go
@@ -12,7 +12,7 @@ import (
 type IteratorError string
 
 func (e IteratorError) Error() string {
-	return string(e)
+	return "levigo: " + string(e)
 }
 
 // Iterator is a read-only iterator through a LevelDB database. It provides a

--- a/options.go
+++ b/options.go
@@ -78,10 +78,10 @@ func (o *Options) SetComparator(cmp *C.leveldb_comparator_t) {
 	C.leveldb_options_set_comparator(o.Opt, cmp)
 }
 
-// SetErrorIfExists, if passed true, will cause the opening of a database that
-// already exists to throw an error.
-func (o *Options) SetErrorIfExists(error_if_exists bool) {
-	eie := boolToUchar(error_if_exists)
+// SetErrorIfExists causes the opening of a database that already exists to
+// throw an error if true.
+func (o *Options) SetErrorIfExists(errorIfExists bool) {
+	eie := boolToUchar(errorIfExists)
 	C.leveldb_options_set_error_if_exists(o.Opt, eie)
 }
 
@@ -110,9 +110,8 @@ func (o *Options) SetWriteBufferSize(s int) {
 	C.leveldb_options_set_write_buffer_size(o.Opt, C.size_t(s))
 }
 
-// SetParanoidChecks, when called with true, will cause the database to do
-// aggressive checking of the data it is processing and will stop early if it
-// detects errors.
+// SetParanoidChecks causes the database to do aggressive checking of the data
+// it is processing and will stop early if it detects errors if true.
 //
 // See the LevelDB documentation docs for details.
 func (o *Options) SetParanoidChecks(pc bool) {

--- a/version.go
+++ b/version.go
@@ -6,10 +6,14 @@ package levigo
 */
 import "C"
 
+// GetLevelDBMajorVersion returns the underlying LevelDB implementation's major
+// version.
 func GetLevelDBMajorVersion() int {
 	return int(C.leveldb_major_version())
 }
 
+// GetLevelDBMinorVersion returns the underlying LevelDB implementation's minor
+// version.
 func GetLevelDBMinorVersion() int {
 	return int(C.leveldb_minor_version())
 }


### PR DESCRIPTION
This commit applies a number of trivial fixes across Levigo to
remedy golint warnings.  One change not associated with lint but
rather overall convention is the inclusion of the package name
prefix/breadcrumb in the emitted error strings.
