### PR TITLE
Add a go.mod file to support Go modules.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/jmhodges/levigo


### PR DESCRIPTION
In order to work well with [Go modules][gomod], packages should have a `go.mod` file and semantic version tags on release versions.

Here I have provided a rudimentary `go.mod` file for levigo.  If you accept this change, and if you are willing to also `git tag v0.0.1 master` and `git push origin v0.0.1` after it is merged, that would begin the release history. I don't know whether you consider the API stable enough for a v1.0.0 release, but users will expect stability so v0 is a safe default.

[gomod]: https://github.com/golang/go/wiki/Modules