### PR TITLE
Make sure to link libstdc++

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1,6 +1,6 @@
 package levigo
 
-// #cgo LDFLAGS: -lleveldb
+// #cgo LDFLAGS: -lleveldb -lstdc++
 // #include "leveldb/c.h"
 import "C"
 


### PR DESCRIPTION
Seems to be necessary when linking in a static MinGW build of LevelDB.

I tried adding this anywhere to `CGO_LDFLAGS`, but that environment variable always ends up at the beginning of the link options. And for some reason, gcc expects `lstdc++` to come at least after `-lleveldb`, and otherwise just ignores it without any indication.
That leaves this source change as the only option.