### PR TITLE
bump ensure-latest-go to v1.0.2

### DIFF
--- a/.github/workflows/ensure_go.yml
+++ b/.github/workflows/ensure_go.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: master
-      - uses: jmhodges/ensure-latest-go@v1.0.1
+      - uses: jmhodges/ensure-latest-go@v1.0.2
         id: ensure_go
       - run: echo "##[set-output name=pr_title;]update to latest Go release ${{ steps.ensure_go.outputs.go_version}}"
         id: pr_title_maker
@@ -20,7 +20,7 @@ jobs:
         uses: peter-evans/create-pull-request@v1.5.2
         env:
           PULL_REQUEST_TITLE: ${{ steps.pr_title_maker.outputs.pr_title }}
-          PULL_REQUEST_BODY: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go). 
+          PULL_REQUEST_BODY: Auto-generated pull request created by the GitHub Actions [create-pull-request](https://github.com/peter-evans/create-pull-request) and [ensure-latest-go](https://github.com/jmhodges/ensure-latest-go).
           COMMIT_MESSAGE: ${{ steps.pr_title_maker.outputs.pr_title }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_SUFFIX: none


### PR DESCRIPTION
Fixed a bug in this repo where the GH action wasn't being updated because no
other travis or dockerfiles were in the repo.