### PR TITLE
update to leveldb 1.22 and add max file size

### DIFF
--- a/.travis/Makefile
+++ b/.travis/Makefile
@@ -1,6 +1,6 @@
 all: test
 
-LEVELDB_VERSION ?= v1.18
+LEVELDB_VERSION ?= 1.22
 SNAPPY_VERSION ?= 1.1.7
 
 export CFLAGS ?= -I$(PWD)/root/snappy-$(SNAPPY_VERSION)/include

--- a/.travis/Makefile
+++ b/.travis/Makefile
@@ -7,7 +7,7 @@ export CFLAGS ?= -I$(PWD)/root/snappy-$(SNAPPY_VERSION)/include
 export CXXFLAGS ?= -I$(PWD)/root/snappy-$(SNAPPY_VERSION)/build
 export LDFLAGS ?= -L$(PWD)/root/snappy-$(SNAPPY_VERSION)/build
 export CGO_CFLAGS ?= -I$(PWD)/root/snappy-$(SNAPPY_VERSION)/build -I$(PWD)/root/leveldb/include
-export CGO_LDFLAGS ?= -L$(PWD)/root/snappy-$(SNAPPY_VERSION)/build -L$(PWD)/root/leveldb -lsnappy
+export CGO_LDFLAGS ?= -L$(PWD)/root/snappy-$(SNAPPY_VERSION)/build -L$(PWD)/root/leveldb/build -lsnappy
 export GOPATH ?= $(PWD)/root/go
 export LD_LIBRARY_PATH := $(PWD)/root/snappy-$(SNAPPY_VERSION)/build:$(PWD)/root/leveldb:$(LD_LIBRARY_PATH)
 
@@ -30,7 +30,8 @@ root/leveldb: root
 
 root/leveldb/STAMP: root/leveldb root/snappy-$(SNAPPY_VERSION)/STAMP
 	cd root/leveldb && git checkout $(LEVELDB_VERSION)
-	$(MAKE) -C root/leveldb
+	cmake --DCMAKE_BUILD_TYPE=Release -S root/leveldb -B root/leveldb/build
+	cmake --build root/leveldb/build
 	touch $@
 
 root/snappy-$(SNAPPY_VERSION): archives/snappy-$(SNAPPY_VERSION).tar.gz root

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/jmhodges/levigo
+module github.com/sattler/levigo
 
 go 1.13

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -35,6 +35,7 @@ func TestC(t *testing.T) {
 	options.SetParanoidChecks(true)
 	options.SetMaxOpenFiles(10)
 	options.SetBlockSize(1024)
+	options.SetMaxFileSize(4 << 20)
 	options.SetBlockRestartInterval(8)
 	options.SetCompression(NoCompression)
 

--- a/options.go
+++ b/options.go
@@ -134,6 +134,14 @@ func (o *Options) SetBlockSize(s int) {
 	C.leveldb_options_set_block_size(o.Opt, C.size_t(s))
 }
 
+// SetMaxFileSize sets the maximum size of a file on the file system.
+//
+// The default is 4MB. A better setting depends on
+// your use case. See the LevelDB documentation for details.
+func (o *Options) SetMaxFileSize(s int) {
+	C.leveldb_options_set_max_file_size(o.Opt, C.size_t(s))
+}
+
 // SetBlockRestartInterval is the number of keys between restarts points for
 // delta encoding keys.
 //


### PR DESCRIPTION
Hi I added the max file size option provided by leveldb in the newer versions published in 2019.